### PR TITLE
Use Intl.NumberFormat to generate CLDR styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Format time duration in quantities of units such as years, months, days, hours, 
 
 The goal of this project is to provide a way to format time durations (like `1 minute 30 seconds`) since the standards don't provide a way to do it.
 
-ECMAScript Internationalization has a long-standing [open issue](https://github.com/tc39/ecma402/issues/47) to provide an `Intl.DurationFormat` API that can accommodate time duration use cases, but there doesn't seem to be any progress.
+ECMAScript Internationalization has a long-standing [open issue](https://github.com/tc39/ecma402/issues/47) to provide an `Intl.DurationFormat` API that can accommodate time duration use cases, but as of February 2020 the [proposal](https://github.com/younies/proposal-intl-duration-format) is still at [Stage 1](https://github.com/tc39/proposals/blob/master/ecma402/README.md).
 
 This project does its best at creating a `DurationFormat` implementation that resembles other standard APIs, but only work with time durations.
 
@@ -44,18 +44,6 @@ This package depends on [intl-messageformat](https://github.com/yahoo/intl-messa
 
 `intl-messageformat` itself depends on the global [`Intl`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) object. Refer to [`intl-messageformat` README](https://github.com/formatjs/formatjs/tree/master/packages/intl-messageformat#modern-intl-dependency) on how to set it up correctly on node.js or in the browser.
 
-### Browser
-
-If you're not using any bundler (webpack / parcel / ...) you can include the IIFE version directly in your HTML file
-
-```html
-<script src="intl-unofficial-duration-unit-format/dist/es5/bundle.iife.min.js"></script>
-```
-
-If you're only targeting modern browsers you can use `dist/es6/` which uses modern language features such as arrow functions, default parameters and so on, for a smaller bundle size.
-
-The script defines a global variable `DurationUnitFormat` which you can use as described above.
-
 ### Webpack / Parcel / Rollup / ....
 
 All modern bundlers allow you to import npm libraries
@@ -83,16 +71,59 @@ Once the duration object is created with `duration = new DurationUnitFormat()`, 
 
 ## Options
 
+## `style`
+
+One of
+
+1. `DurationUnitFormat.styles.LONG` or just `long` for long format time (`1 minute 30 seconds`)
+1. `DurationUnitFormat.styles.SHORT` or just `short` for short format time (`1 min 30 sec`)
+1. `DurationUnitFormat.styles.NARROW` or just `narrow` for narrow format time (`1m 30s`)
+1. `DurationUnitFormat.styles.TIMER` for timers (`1:30`)
+1. `DurationUnitFormat.styles.CUSTOM` for custom formats (`1 minute 30 seconds`)
+
+The default is `LONG`.
+
+When the style is `TIMER` numbers are padded and different default formats are applied.
+
+The other options `format`, `formatDuration` and `formatUnits` only apply when the style is `CUSTOM`.
+
+Given the input of `3600` (1 hour), it'll generate
+
+| `style`  | `format` |Output |
+|----------|----------|--------|
+| `CUSTOM` | undefined (defaults to `{seconds}`) | `3600 seconds` |
+| `CUSTOM` | `{minutes} {seconds}` | `60 minutes` |
+| `CUSTOM` | `{hour} {minutes} {seconds}` | `1 hour` |
+| `TIMER`  | undefined (defaults to `{minutes}:{seconds}`)| `60:00` |
+| `TIMER`  | `{seconds}s` | `3600s` |
+| `TIMER`  | `{hour}:{minutes}:{seconds}` | `1:00:00` |
+| `TIMER`  | `{days}d {hour}:{minutes}:{seconds}` | `0d 01:00:00` |
+| `LONG`   | undefined (defaults to `{seconds}`) | `3600 seconds` |
+| `LONG`   | `{minutes} {seconds}` | `60 minutes` |
+| `LONG`   | `{hour} {minutes} {seconds}` | `1 hour` |
+| `SHORT`  | undefined (defaults to `{seconds}`) | `3600 sec` |
+| `SHORT`  | `{minutes} {seconds}` | `60 min` |
+| `SHORT`  | `{hour} {minutes} {seconds}` | `1 hr` |
+| `NARROW` | undefined (defaults to `{seconds}`) | `3600s` |
+| `NARROW` | `{minutes} {seconds}` | `60m` |
+| `NARROW` | `{hour} {minutes} {seconds}` | `1h` |
+
+As shown from the examples, when `TIMER` is used
+
+1. empty units are kept and rendered as `00` or `0` if they're the highest unit in the format. Empty units in `CUSTOM` are discarded.
+1. values are padded to at least 2 digits
+
+
 ### `format`
 
-Defines the format of the output string. Default to `{seconds}`.
+Custom format of the output string. Default to `{seconds}`.
 
 It can be any string containing any of the placeholders `{days}`, `{hours}`, `{minutes}`, `{seconds}` or any other literal. The format of the placeholders can be customized by [`formatDuration`](#formatDuration).
 
 Given the input of `3661` (1 hour, 1 minute and 1 second), it'll generate
 
 | `format` | Output |
-|--------|--------|
+|----------|--------|
 | `{seconds}` | `3661 seconds` |
 | `{minutes} {seconds}` | `61 minutes 1 second` |
 | `{minutes} and {seconds}` | `61 minutes and 1 second` |
@@ -100,21 +131,21 @@ Given the input of `3661` (1 hour, 1 minute and 1 second), it'll generate
 | `{hours} {minutes}` | `1 hour 1 minute` |
 | `{hours}` | `1 hour` |
 | `{hours}` | `1 hour` |
-| `{days}` | `0 days` |
+| `{days}`  | `0 days` |
 
 
 ### `formatDuration`
 
-Defines the format of the output placeholders. Defaults to `{value} {unit}`.
+Defines the format of the output placeholders. Default to `{value} {unit}`.
 
 It can be any string containing `{value}`, `{unit}` or any other literal. `{value}` corresponds to the numeric value (`1`), while `{unit}` is the time unit (`minute`, `second`).
 
 Given the input of `1`, it'll generate
 
-| `formatDuration` | Output |
-|--------|--------|
-| `{value} {unit}` | `1 second` |
-| `{value}{unit}` | `1second` |
+| `formatDuration`  | Output      |
+|-------------------|-------------|
+| `{value} {unit}`  | `1 second`  |
+| `{value}{unit}`   | `1second`   |
 | `{unit}: {value}` | `second: 1` |
 
 ## `formatUnits`
@@ -140,62 +171,13 @@ Given the input of `1`, it'll generate
 | `{value, plural, other {秒}}` | `秒` |
 | `s` | `s` |
 
-The formats and localization of placeholders for the style `LONG`, `SHORT` and `NARROW` can be configured with
-
-```js
-{
-  [`${DurationUnitFormat.units.DAY}-${DurationUnitFormat.styles.LONG}`]: '{value, plural, one {day} other {days}}',
-  [`${DurationUnitFormat.units.DAY}-${DurationUnitFormat.styles.SHORT}`]: '{value, plural, one {day} other {days}}',
-  [`${DurationUnitFormat.units.DAY}-${DurationUnitFormat.styles.NARROW}`]: 'd',
-}
-
 ## `round`
 
-Whether or not to round results when smaller units are missing. Defaults to `false`.
+Whether or not to round results when smaller units are missing. Default to `false`.
 
 Given the input of `30` and the format `{minutes}`
 
-| `round` | Output |
-|--------|--------|
+| `round` | Output      |
+|---------|-------------|
 | `false` | `0 minutes` |
-| `true` | `1 minute` |
-
-## `style`
-
-One of
-
-1. `DurationUnitFormat.styles.TIMER` for timers (`1:30`)
-1. `DurationUnitFormat.styles.CUSTOM` for custom formats (`1 minute 30 seconds`)
-1. `DurationUnitFormat.styles.LONG` for long format time (`1 minute 30 seconds`)
-1. `DurationUnitFormat.styles.SHORT` for short format time (`1 min 30 sec`)
-1. `DurationUnitFormat.styles.NARROW` for narrow format time (`1m 30s`)
-
-The default is `CUSTOM`.
-
-When the style is `TIMER` numbers are padded and different default formats are applied
-
-Given the input of `3600` (1 hour), it'll generate
-
-| `style` | `format` |Output |
-|--------|--------|--------|
-| `CUSTOM` | undefined (defaults to `{seconds}`) | `3600 seconds` |
-| `CUSTOM` | `{minutes} {seconds}` | `60 minutes` |
-| `CUSTOM` | `{hour} {minutes} {seconds}` | `1 hour` |
-| `TIMER` | undefined (defaults to `{minutes}:{seconds}`)| `60:00` |
-| `TIMER` | `{seconds}s` | `3600s` |
-| `TIMER` | `{hour}:{minutes}:{seconds}` | `1:00:00` |
-| `TIMER` | `{days}d {hour}:{minutes}:{seconds}` | `0d 01:00:00` |
-| `LONG` | undefined (defaults to `{seconds}`) | `3600 seconds` |
-| `LONG` | `{minutes} {seconds}` | `60 minutes` |
-| `LONG` | `{hour} {minutes} {seconds}` | `1 hour` |
-| `SHORT` | undefined (defaults to `{seconds}`) | `3600 sec` |
-| `SHORT` | `{minutes} {seconds}` | `60 min` |
-| `SHORT` | `{hour} {minutes} {seconds}` | `1 hr` |
-| `NARROW` | undefined (defaults to `{seconds}`) | `3600s` |
-| `NARROW` | `{minutes} {seconds}` | `60m` |
-| `NARROW` | `{hour} {minutes} {seconds}` | `1h` |
-
-As shown from the examples, when `TIMER` is used
-
-1. empty units are kept and rendered as `00` or `0` if they're the highest unit in the format. Empty units in `CUSTOM` are discarded.
-1. values are padded to at least 2 digits
+| `true`  | `1 minute`  |

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ As shown from the examples, when `TIMER` is used
 1. empty units are kept and rendered as `00` or `0` if they're the highest unit in the format. Empty units in `CUSTOM` are discarded.
 1. values are padded to at least 2 digits
 
+Note that on Node.js 10.x, the default implementation of Intl.NumberFormat does not support styles, so you need to use the `@formatjs/intl-unified-numberformat` polyfill.
 
 ### `format`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2441,6 +2441,21 @@
         "minimist": "^1.2.0"
       }
     },
+    "@formatjs/intl-unified-numberformat": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-3.3.1.tgz",
+      "integrity": "sha512-ZmSxfs7Vt1qnF4AmOuN1XVFK3rXPTxEW4K6mjEJjJkWlgmqSbZeLg7Q46c4GfU6x5dbHVFCaIWsy+U2ko6WkfA==",
+      "dev": true,
+      "requires": {
+        "@formatjs/intl-utils": "^2.2.1"
+      }
+    },
+    "@formatjs/intl-utils": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.2.1.tgz",
+      "integrity": "sha512-WF3oU6l2WqJjN4OWvnjF9AHyQjHpjcfpyuckM7euFeX6ZGRPpPj+ZCqzf41g81MSksf9aZI4fFCZXWTBusgcWA==",
+      "dev": true
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -4624,35 +4639,35 @@
       "dev": true
     },
     "intl-format-cache": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-4.2.8.tgz",
-      "integrity": "sha512-GzMvyEyMO9yoxCnudRK7r5RRfS6nNRZOHdmZj1vLrFDXkpRHz7uK1YouYxHQHqhlX8K1kmyAmO0WBqFPq2caAQ==",
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-4.2.23.tgz",
+      "integrity": "sha512-a1chSSjN323lnm3f4VWR/+6uyaXgTLII8PkiDeKkC3A+eauUswf/k09iBwDQGlkLg29mZ+zShWdm+YdH+sLY4w==",
       "dev": true
     },
     "intl-messageformat": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-7.5.4.tgz",
-      "integrity": "sha512-gJIxdZifeetsfI51AWtlFbpr+edgFj+F3bXz6HgW+g/g1Ch6y8bxLGu1IR8Qg5aqkmDdF8IbSSycXITpokCCow==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-8.3.4.tgz",
+      "integrity": "sha512-mjS/M10RvZ0Zz5ld5+Op3ZFv9gfyfQhCYwg+b++66wBM9vRqiFjCq96psdSJ48VzDd5TqYx3dVxAVeZs+4ZmtQ==",
       "dev": true,
       "requires": {
-        "intl-format-cache": "^4.2.8",
-        "intl-messageformat-parser": "^3.2.4"
+        "intl-format-cache": "^4.2.23",
+        "intl-messageformat-parser": "^4.1.2"
       }
     },
     "intl-messageformat-parser": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-3.2.4.tgz",
-      "integrity": "sha512-S7RATYskl2cMvV4X4PUc9yiALQy9F4WNnoeRH/NgFxJ7WgFhSzMIjRr8Zz6KY+QITNdkM7gNJbXlW9Mnoi7PVg==",
-      "dev": true
-    },
-    "intl-pluralrules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/intl-pluralrules/-/intl-pluralrules-1.1.1.tgz",
-      "integrity": "sha512-o00S+9UDHcAAHAriMVZwrGH3CX8mgG74r4TT7Onidx9P6Q9GJKDkp17RD9eU9AFH9LGBJz/xqDUvarud0vk1wQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-4.1.2.tgz",
+      "integrity": "sha512-elPjsKkp5L1C60/DPw1jAxmv7ikSpFqmx5NEWeg6DjcZoNr7ZSk+S4Bj9WG5zsJdHF3QfVYr0AbQvDaq6DioqA==",
       "dev": true,
       "requires": {
-        "make-plural": "^6.0.1"
+        "@formatjs/intl-unified-numberformat": "^3.3.1"
       }
+    },
+    "intl-pluralrules": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/intl-pluralrules/-/intl-pluralrules-1.2.0.tgz",
+      "integrity": "sha512-7v29fFKsaPquXezxttUNFdE6LQUD41I8JX76royEWBPuYIEruvfvprU3d8CsiNVIieVg/VeV2ee5WI0w0Vs2Sg==",
+      "dev": true
     },
     "invariant": {
       "version": "2.2.4",
@@ -6565,12 +6580,6 @@
         }
       }
     },
-    "make-plural": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-6.0.1.tgz",
-      "integrity": "sha512-h0uBNi4tpDkiWUyYKrJNj8Kif6q3Ba5zp/8jnfPy3pQE+4XcTj6h3eZM5SYVUyDNX9Zk69Isr/dx0I+78aJUaQ==",
-      "dev": true
-    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -7389,9 +7398,9 @@
       }
     },
     "rollup": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.4.0.tgz",
-      "integrity": "sha512-dYE2ZKl9+kxuFKDaaSuauZjIPa8hcKDqI7WrOq1pTXYG4GJw+6ypLifGIvCKw5yJpSmuFohuimYpg0wfRXTCLw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.6.0.tgz",
+      "integrity": "sha512-qbvQ9ZbvbhBdtRBZ/A4g+9z3iJQ1rHAtjinn3FiN+j5tfz8xiNyTE1JEEMcFWqlH7+NHadI9ieeqKdp8HwYLnQ==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"

--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
     "@babel/core": "7.9.0",
     "@babel/preset-env": "7.9.5",
     "babel-jest": "25.3.0",
-    "intl-messageformat": "7.5.4",
-    "intl-pluralrules": "1.1.1",
+    "intl-messageformat": "8.3.4",
+    "intl-pluralrules": "1.2.0",
     "jest": "25.3.0",
-    "rollup": "2.4.0",
+    "rollup": "2.6.0",
     "rollup-plugin-filesize": "7.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@babel/core": "7.9.0",
     "@babel/preset-env": "7.9.5",
+    "@formatjs/intl-unified-numberformat": "3.3.1",
     "babel-jest": "25.3.0",
     "intl-messageformat": "8.3.4",
     "intl-pluralrules": "1.2.0",

--- a/tests/_setup.js
+++ b/tests/_setup.js
@@ -1,3 +1,11 @@
 require('intl-pluralrules');
 // NumberFormat polyfill needed on node 10
 require('@formatjs/intl-unified-numberformat/polyfill');
+if (typeof Intl.NumberFormat.__addLocaleData === 'function') {
+  Intl.NumberFormat.__addLocaleData(
+    require('@formatjs/intl-unified-numberformat/dist/locale-data/en.json')
+  );
+  Intl.NumberFormat.__addLocaleData(
+    require('@formatjs/intl-unified-numberformat/dist/locale-data/ja.json')
+  );
+}

--- a/tests/_setup.js
+++ b/tests/_setup.js
@@ -3,9 +3,9 @@ require('intl-pluralrules');
 require('@formatjs/intl-unified-numberformat/polyfill');
 if (typeof Intl.NumberFormat.__addLocaleData === 'function') {
   Intl.NumberFormat.__addLocaleData(
-    require('@formatjs/intl-unified-numberformat/dist/locale-data/en.json')
+    require('@formatjs/intl-unified-numberformat/dist/locale-data/en.json'),
   );
   Intl.NumberFormat.__addLocaleData(
-    require('@formatjs/intl-unified-numberformat/dist/locale-data/ja.json')
+    require('@formatjs/intl-unified-numberformat/dist/locale-data/ja.json'),
   );
 }

--- a/tests/_setup.js
+++ b/tests/_setup.js
@@ -1,1 +1,3 @@
 require('intl-pluralrules');
+// NumberFormat polyfill needed on node 10
+require('@formatjs/intl-unified-numberformat/polyfill');

--- a/tests/units-durations.test.js
+++ b/tests/units-durations.test.js
@@ -1,0 +1,67 @@
+import DurationUnitFormat from '../index';
+
+describe('formatToParts', () => {
+  it('formats to parts with custom format for units and durations', () => {
+    const parts = DurationUnitFormat.prototype.formatToParts.bind(new DurationUnitFormat('en', {
+      style: 'custom',
+      format: '{hours} + {minutes}',
+      formatDuration: '{unit}: {value}',
+      formatUnits: {
+        hour: 'H',
+        minute: 'M',
+      },
+    }));
+
+    expect(parts(0)).toEqual([
+      { type: 'unit', value: 'M' },
+      { type: 'literal', value: ': ' },
+      { type: 'minute', value: '0' },
+    ]);
+    expect(parts(1)).toEqual([
+      { type: 'unit', value: 'M' },
+      { type: 'literal', value: ': ' },
+      { type: 'minute', value: '0' },
+    ]);
+    expect(parts(30)).toEqual([
+      { type: 'unit', value: 'M' },
+      { type: 'literal', value: ': ' },
+      { type: 'minute', value: '0' },
+    ]);
+    expect(parts(60)).toEqual([
+      { type: 'literal', value: ' + ' },
+      { type: 'unit', value: 'M' },
+      { type: 'literal', value: ': ' },
+      { type: 'minute', value: '1' },
+    ]);
+    expect(parts(119)).toEqual([
+      { type: 'literal', value: ' + ' },
+      { type: 'unit', value: 'M' },
+      { type: 'literal', value: ': ' },
+      { type: 'minute', value: '1' },
+    ]);
+    expect(parts(60 * 60 - 40)).toEqual([ // 40 seconds before 1h
+      { type: 'literal', value: ' + ' },
+      { type: 'unit', value: 'M' },
+      { type: 'literal', value: ': ' },
+      { type: 'minute', value: '59' },
+    ]);
+    expect(parts(60 * 60 - 1)).toEqual([ // 1 second before 1h
+      { type: 'literal', value: ' + ' },
+      { type: 'unit', value: 'M' },
+      { type: 'literal', value: ': ' },
+      { type: 'minute', value: '59' },
+    ]);
+    expect(parts(10 * 60 * 60)).toEqual([
+      { type: 'unit', value: 'H' },
+      { type: 'literal', value: ': ' },
+      { type: 'hour', value: '10' },
+      { type: 'literal', value: ' + ' },
+    ]);
+    expect(parts(100 * 60 * 60)).toEqual([
+      { type: 'unit', value: 'H' },
+      { type: 'literal', value: ': ' },
+      { type: 'hour', value: '100' },
+      { type: 'literal', value: ' + ' },
+    ]);
+  });
+});


### PR DESCRIPTION
`long`, `short` and `narrow` are standard in CLDR, so use Intl.NumberFromat to generate them instead of adding even more custom formats.