### PR TITLE
Implement `format()`; fixes #13

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function DurationUnitFormat(locales, options = defaultOptions) {
   // .isTimer determines some special behaviour, we want to keep the 0s
   this.isTimer = this.style === DurationUnitFormat.styles.TIMER;
   // .format used `seconds`, `minutes`, `hours`, ... as placeholders
-  this.format = options.format || (this.isTimer ? '{minutes}:{seconds}' : '{seconds}');
+  this._format = options.format || (this.isTimer ? '{minutes}:{seconds}' : '{seconds}');
   // How to format unit according to style
   this.formatUnits = options.formatUnits || defaultOptions.formatUnits;
   // .formatDuration determines whether we use a space or not
@@ -34,9 +34,13 @@ DurationUnitFormat.styles = {
   NARROW: 'narrow',
 };
 
+DurationUnitFormat.prototype.format = function (value) {
+  return this.formatToParts(value).map(({ value }) => value).join('');
+};
+
 DurationUnitFormat.prototype.formatToParts = function (value) {
   // Extract all the parts that are actually used from the localised format
-  const parts = new IntlMessageFormat(this.format, this.locales).formatToParts({
+  const parts = new IntlMessageFormat(this._format, this.locales).formatToParts({
     second: { unit: DurationUnitFormat.units.SECOND },
     seconds: { unit: DurationUnitFormat.units.SECOND },
     minute: { unit: DurationUnitFormat.units.MINUTE },

--- a/tests/format.test.js
+++ b/tests/format.test.js
@@ -1,0 +1,15 @@
+import DurationUnitFormat from '../index';
+
+describe('format', () => {
+  it('formats with default format of only seconds', () => {
+    const output = DurationUnitFormat.prototype.format.bind(new DurationUnitFormat('en'));
+
+    expect(output(0)).toEqual('0 seconds');
+    expect(output(1)).toEqual('1 second');
+    expect(output(30)).toEqual('30 seconds');
+    expect(output(59)).toEqual('59 seconds');
+    expect(output(60)).toEqual('60 seconds');
+    expect(output(61)).toEqual('61 seconds');
+    expect(output(120)).toEqual('120 seconds');
+  });
+});


### PR DESCRIPTION
This just adopts the implementation offered in #13.

Assuming this is sufficient, I'm not sure how you might want any other tests structured (assuming you want other tests since it is just wrapping `formatToParts`).

Eager to use this for some i18n.

Thanks!